### PR TITLE
Update error message in http_allowed_ips to reflect new way of allowi…

### DIFF
--- a/core/utils/http_allowed_ips.go
+++ b/core/utils/http_allowed_ips.go
@@ -70,7 +70,7 @@ func restrictedDialContext(ctx context.Context, network, address string) (net.Co
 
 		if isRestrictedIP(a.IP) {
 			defer logger.ErrorIfCalling(con.Close)
-			return nil, fmt.Errorf("disallowed IP %s. Connections to local/private and multicast networks are disabled by default for security reasons. If you really want to allow this, consider using the httpgetwithunrestrictednetworkaccess or httppostwithunrestrictednetworkaccess adapter instead", a.IP.String())
+			return nil, fmt.Errorf("disallowed IP %s. Connections to local/private and multicast networks are disabled by default for security reasons. If you really want to allow this, consider setting the allowunrestrictednetworkaccess option on the task to true", a.IP.String())
 		}
 	}
 	return con, err


### PR DESCRIPTION
…ng unrestricted access

The `httpgetwithunrestrictednetworkaccess` tasks no longer exist, and the HttpTaskType now has a bool option